### PR TITLE
Fix for Inconsistent equality and hashing

### DIFF
--- a/src/xmmutablemap/_core.py
+++ b/src/xmmutablemap/_core.py
@@ -96,10 +96,12 @@ class ImmutableMap(Mapping[K, V]):
         if isinstance(other, Mapping):
             if len(self._data) != len(other):
                 return False
-            sentinel = object()
-            return all(
-                self._data.get(key, sentinel) == value for key, value in other.items()
-            )
+            for key, value in other.items():
+                if key not in self._data:
+                    return False
+                if self._data[key] != value:
+                    return False
+            return True
         return NotImplemented
 
     # ===========================================

--- a/src/xmmutablemap/_core.py
+++ b/src/xmmutablemap/_core.py
@@ -89,6 +89,14 @@ class ImmutableMap(Mapping[K, V]):
         """
         return len(self._data)
 
+    def __eq__(self, other: Any) -> bool:
+        """Return whether two mappings contain the same items."""
+        if isinstance(other, ImmutableMap):
+            return self._data == other._data
+        if isinstance(other, Mapping):
+            return self._data == dict(other.items())
+        return NotImplemented
+
     # ===========================================
     # Mapping Protocol
 

--- a/src/xmmutablemap/_core.py
+++ b/src/xmmutablemap/_core.py
@@ -89,7 +89,7 @@ class ImmutableMap(Mapping[K, V]):
         """
         return len(self._data)
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Return whether two mappings contain the same items."""
         if isinstance(other, ImmutableMap):
             return self._data == other._data

--- a/src/xmmutablemap/_core.py
+++ b/src/xmmutablemap/_core.py
@@ -93,6 +93,8 @@ class ImmutableMap(Mapping[K, V]):
         """Return whether two mappings contain the same items."""
         if isinstance(other, ImmutableMap):
             return self._data == other._data
+        if isinstance(other, dict):
+            return self._data = other
         if isinstance(other, Mapping):
             return self._data == dict(other.items())
         return NotImplemented

--- a/src/xmmutablemap/_core.py
+++ b/src/xmmutablemap/_core.py
@@ -99,6 +99,10 @@ class ImmutableMap(Mapping[K, V]):
             return self._data == dict(other.items())
         return NotImplemented
 
+    def __hash__(self) -> int:
+        """Return an order-insensitive hash based on the mapping contents."""
+        return hash(frozenset(self._data.items()))
+
     # ===========================================
     # Mapping Protocol
 

--- a/src/xmmutablemap/_core.py
+++ b/src/xmmutablemap/_core.py
@@ -97,9 +97,11 @@ class ImmutableMap(Mapping[K, V]):
             if len(self._data) != len(other):
                 return False
             for key, value in other.items():
-                if key not in self._data:
+                try:
+                    self_value = self._data[key]
+                except KeyError:
                     return False
-                if self._data[key] != value:
+                if self_value != value:
                     return False
             return True
         return NotImplemented

--- a/src/xmmutablemap/_core.py
+++ b/src/xmmutablemap/_core.py
@@ -94,7 +94,12 @@ class ImmutableMap(Mapping[K, V]):
         if isinstance(other, ImmutableMap):
             return self._data == other._data
         if isinstance(other, Mapping):
-            return self._data == dict(other.items())
+            if len(self._data) != len(other):
+                return False
+            sentinel = object()
+            return all(
+                self._data.get(key, sentinel) == value for key, value in other.items()
+            )
         return NotImplemented
 
     # ===========================================

--- a/src/xmmutablemap/_core.py
+++ b/src/xmmutablemap/_core.py
@@ -93,15 +93,9 @@ class ImmutableMap(Mapping[K, V]):
         """Return whether two mappings contain the same items."""
         if isinstance(other, ImmutableMap):
             return self._data == other._data
-        if isinstance(other, dict):
-            return self._data = other
         if isinstance(other, Mapping):
             return self._data == dict(other.items())
         return NotImplemented
-
-    def __hash__(self) -> int:
-        """Return an order-insensitive hash based on the mapping contents."""
-        return hash(frozenset(self._data.items()))
 
     # ===========================================
     # Mapping Protocol
@@ -229,7 +223,7 @@ class ImmutableMap(Mapping[K, V]):
         True
 
         """
-        return hash(tuple(self._data.items()))
+        return hash(frozenset(self._data.items()))
 
     def __repr__(self) -> str:
         """Return the representation.

--- a/tests/test_immutablemap.py
+++ b/tests/test_immutablemap.py
@@ -67,9 +67,16 @@ class TestImmutableMap:
     def test_eq_with_other_mappings(self) -> None:
         """Test mapping interoperability for `__eq__`."""
         d = ImmutableMap(a=1, b=2)
+        other_dict = {"a": 1, "b": 2}
+        other_ordered_dict = OrderedDict([("a", 1), ("b", 2)])
+        other_proxy = MappingProxyType({"a": 1, "b": 2})
+
         assert d == {"a": 1, "b": 2}
         assert d == OrderedDict([("a", 1), ("b", 2)])
         assert d == MappingProxyType({"a": 1, "b": 2})
+        assert other_dict == d
+        assert other_ordered_dict == d
+        assert other_proxy == d
 
     def test_eq_and_hash_ignore_insertion_order(self) -> None:
         """Test equality/hash contract for same items in different orders."""

--- a/tests/test_immutablemap.py
+++ b/tests/test_immutablemap.py
@@ -57,12 +57,25 @@ class TestImmutableMap:
 
     def test_hash(self, d: ImmutableMap[str, Any]) -> None:
         """Test `__hash__`."""
-        assert hash(d) == hash(tuple(d.items()))
+        assert hash(d) == hash(frozenset(d.items()))
 
         # Not hashable if values aren't hashable.
         d = ImmutableMap(a=1, b={"c"})
         with pytest.raises(TypeError, match="unhashable type: 'set'"):
             hash(d)
+
+    def test_eq_with_other_mappings(self, d: ImmutableMap[str, Any]) -> None:
+        """Test mapping interoperability for `__eq__`."""
+        assert d == {"a": 1, "b": 2}
+        assert d == OrderedDict([("a", 1), ("b", 2)])
+        assert d == MappingProxyType({"a": 1, "b": 2})
+
+    def test_eq_and_hash_ignore_insertion_order(self) -> None:
+        """Test equality/hash contract for same items in different orders."""
+        d1 = ImmutableMap(a=1, b=2)
+        d2 = ImmutableMap(b=2, a=1)
+        assert d1 == d2
+        assert hash(d1) == hash(d2)
 
     def test_keys(self, d: ImmutableMap[str, Any]) -> None:
         """Test `keys`."""

--- a/tests/test_immutablemap.py
+++ b/tests/test_immutablemap.py
@@ -64,8 +64,9 @@ class TestImmutableMap:
         with pytest.raises(TypeError, match="unhashable type: 'set'"):
             hash(d)
 
-    def test_eq_with_other_mappings(self, d: ImmutableMap[str, Any]) -> None:
+    def test_eq_with_other_mappings(self) -> None:
         """Test mapping interoperability for `__eq__`."""
+        d = ImmutableMap(a=1, b=2)
         assert d == {"a": 1, "b": 2}
         assert d == OrderedDict([("a", 1), ("b", 2)])
         assert d == MappingProxyType({"a": 1, "b": 2})


### PR DESCRIPTION
To fix this safely, implement `__eq__` on `ImmutableMap` so equality is based on contained key/value pairs, and ensure it interoperates with other mappings. The best approach is to compare the underlying data dict when `other` is an `ImmutableMap`, and compare against `dict(other.items())` when `other` is any `Mapping`; otherwise return `NotImplemented`.

In `src/xmmutablemap/_core.py`, add a new `__eq__` method inside `ImmutableMap` (near other protocol methods, e.g., after `__len__`). No new imports are required since `Any` and `Mapping` are already imported. This preserves existing functionality while making hashing/equality contract explicit and correct.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._